### PR TITLE
Pin axios to exact version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^24.0.12",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
-        "axios": "^1.10.0",
+        "axios": "1.10.0",
         "got": "^14.4.4",
         "jest": "^30.0.4",
         "json-schema-merge-allof": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^24.0.12",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "axios": "^1.10.0",
+    "axios": "1.10.0",
     "got": "^14.4.4",
     "jest": "^30.0.4",
     "json-schema-merge-allof": "^0.8.1",


### PR DESCRIPTION
## Summary
- Remove caret range (`^1.10.0` → `1.10.0`) to prevent resolving a compromised axios version on fresh install or update
- Context: axios@1.14.1 and axios@0.30.4 were compromised via the `plain-crypto-js` malware package ([ref](https://socket.dev/blog/axios-supply-chain-attack))

## Test plan
- [ ] `npm ci` still works (lockfile already pins 1.10.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; it only restricts version resolution and shouldn’t affect runtime behavior beyond preventing accidental upgrades.
> 
> **Overview**
> Pins `axios` in `package.json` from `^1.10.0` to the exact `1.10.0` to prevent fresh installs/updates from resolving to newer (potentially compromised) versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8db67732ad844bbfc12139ff5c4151f417c4acb0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->