### PR TITLE
[pkg-vet-test][do-not-merge] S1 clean devDep: dotenv@17.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "selfsigned": "^3.0.1",
         "ts-jest": "^29.4.0",
         "tsup": "^8.5.0",
-        "tsx": "^4.20.3"
+        "tsx": "^4.20.3",
+        "dotenv": "^17.4.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7251,6 +7252,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "selfsigned": "^3.0.1",
     "ts-jest": "^29.4.0",
     "tsup": "^8.5.0",
-    "tsx": "^4.20.3"
+    "tsx": "^4.20.3",
+    "dotenv": "^17.4.2"
   },
   "dependencies": {
     "@gldywn/crlset.js": "^1.2.0",


### PR DESCRIPTION
Throwaway fixture to exercise pkg-vet + Aikido on a clean dependency addition. Adds dotenv@17.4.2 (clean, zero-dependency) as a devDependency. DO NOT MERGE; closed once the scan is captured.