### PR TITLE
[pkg-vet-test][do-not-merge] S2 vulnerable devDep: ini@1.3.5 (prototype pollution)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "selfsigned": "^3.0.1",
         "ts-jest": "^29.4.0",
         "tsup": "^8.5.0",
-        "tsx": "^4.20.3"
+        "tsx": "^4.20.3",
+        "ini": "1.3.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7251,6 +7252,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "selfsigned": "^3.0.1",
     "ts-jest": "^29.4.0",
     "tsup": "^8.5.0",
-    "tsx": "^4.20.3"
+    "tsx": "^4.20.3",
+    "ini": "1.3.5"
   },
   "dependencies": {
     "@gldywn/crlset.js": "^1.2.0",


### PR DESCRIPTION
Throwaway fixture to exercise pkg-vet + Aikido SCA on a known-vulnerable dependency. Adds ini@1.3.5 (GHSA-qqgx-2p2h-9c37 / CVE-2020-7788 prototype pollution, fixed in 1.3.6). Vulnerable, not malicious. DO NOT MERGE; closed once the scan is captured.