### PR TITLE
[pkg-vet-test][do-not-merge] S3 malware ref: flatmap-stream@0.1.1 (DEAD tarball, cannot install)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "selfsigned": "^3.0.1",
         "ts-jest": "^29.4.0",
         "tsup": "^8.5.0",
-        "tsx": "^4.20.3"
+        "tsx": "^4.20.3",
+        "flatmap-stream": "0.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7251,6 +7252,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flatmap-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "selfsigned": "^3.0.1",
     "ts-jest": "^29.4.0",
     "tsup": "^8.5.0",
-    "tsx": "^4.20.3"
+    "tsx": "^4.20.3",
+    "flatmap-stream": "0.1.1"
   },
   "dependencies": {
     "@gldywn/crlset.js": "^1.2.0",


### PR DESCRIPTION
Throwaway fixture to verify pkg-vet + Aikido MALWARE detection. References flatmap-stream@0.1.1 (event-stream 2018 incident payload, OSV MAL-2025-20690). Registry tarball is HTTP 404 (taken down) and the lockfile entry has no integrity, so npm ci aborts at fetch before any lifecycle script: cannot be installed or executed. DO NOT MERGE; closed once the scan is captured.