### PR TITLE
[pkg-vet-test][do-not-merge] S2c reachable ini@1.3.5 (calls ini.parse)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "asn1js": "^3.0.6",
         "easy-ocsp": "^1.3.0",
         "pkijs": "^3.2.5",
-        "web-streams-polyfill": "^4.1.0"
+        "web-streams-polyfill": "^4.1.0",
+        "ini": "1.3.5"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -7251,6 +7252,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "asn1js": "^3.0.6",
     "easy-ocsp": "^1.3.0",
     "pkijs": "^3.2.5",
-    "web-streams-polyfill": "^4.1.0"
+    "web-streams-polyfill": "^4.1.0",
+    "ini": "1.3.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,10 @@ export {
 
 export { createTemplateFormatter } from './logger';
 export type { LogSink, BindableLogSink, LogFormatter, LogLevel } from './logger';
+
+// pkg-vet reachability test fixture (do-not-merge): exercises the vulnerable ini.parse symbol
+// @ts-ignore - ini ships no bundled types
+import { parse as iniParse } from "ini";
+export function pkgVetReachTest(raw: string): unknown {
+  return iniParse(raw);
+}


### PR DESCRIPTION
Throwaway fixture: ini@1.3.5 (GHSA-qqgx-2p2h-9c37 prototype pollution) added as a runtime dependency AND its vulnerable parse() called from an exported function, so the vuln is reachable. Tests whether Aikido flags a reachable dependency vulnerability. DO NOT MERGE.