### PR TITLE
[pkg-vet-test][do-not-merge] S4 reachable node-serialize@0.0.4 RCE (CVE-2017-5941)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "asn1js": "^3.0.6",
         "easy-ocsp": "^1.3.0",
         "pkijs": "^3.2.5",
-        "web-streams-polyfill": "^4.1.0"
+        "web-streams-polyfill": "^4.1.0",
+        "node-serialize": "0.0.4"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -7251,6 +7252,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/node-serialize": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/node-serialize/-/node-serialize-0.0.4.tgz",
+      "integrity": "sha512-Q7krX4keanOtqYrNWGlTWk0jSYPewtMpzs5AoV0NieqTtQkLRGq5e0R+iuTA3npbpk7B1zJy6dZ7o9wmmuEYmA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "asn1js": "^3.0.6",
     "easy-ocsp": "^1.3.0",
     "pkijs": "^3.2.5",
-    "web-streams-polyfill": "^4.1.0"
+    "web-streams-polyfill": "^4.1.0",
+    "node-serialize": "0.0.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,10 @@ export {
 
 export { createTemplateFormatter } from './logger';
 export type { LogSink, BindableLogSink, LogFormatter, LogLevel } from './logger';
+
+// pkg-vet reachability test fixture (do-not-merge): exercises node-serialize.unserialize (CVE-2017-5941, EPSS ~78%)
+// @ts-ignore - node-serialize ships no types
+import nodeSerialize from "node-serialize";
+export function pkgVetReachRce(raw: string): unknown {
+  return nodeSerialize.unserialize(raw);
+}


### PR DESCRIPTION
Throwaway fixture: node-serialize@0.0.4 (CVE-2017-5941 deserialization RCE, EPSS ~78pct) as a runtime dependency with its vulnerable unserialize() called from an exported function. High EPSS so it should NOT be auto-ignored. Vulnerable, not malware, no install scripts. DO NOT MERGE.