### PR TITLE
[pkg-vet-test][do-not-merge] S5 malware @ctrl/tinycolor (Shai-Hulud, direct + transitive)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "asn1js": "^3.0.6",
         "easy-ocsp": "^1.3.0",
         "pkijs": "^3.2.5",
-        "web-streams-polyfill": "^4.1.0"
+        "web-streams-polyfill": "^4.1.0",
+        "@ctrl/tinycolor": "4.1.1",
+        "dotenv": "^17.4.2"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -7251,6 +7253,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.1.tgz"
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dependencies": {
+        "@ctrl/tinycolor": "4.1.2"
+      }
+    },
+    "node_modules/dotenv/node_modules/@ctrl/tinycolor": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.2.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "asn1js": "^3.0.6",
     "easy-ocsp": "^1.3.0",
     "pkijs": "^3.2.5",
-    "web-streams-polyfill": "^4.1.0"
+    "web-streams-polyfill": "^4.1.0",
+    "@ctrl/tinycolor": "4.1.1",
+    "dotenv": "^17.4.2"
   }
 }


### PR DESCRIPTION
Throwaway fixture for Aikido Malware Scan. @ctrl/tinycolor@4.1.1 DIRECT and @4.1.2 TRANSITIVE (synthetic edge under a dotenv wrapper). Both Shai-Hulud worm versions (OSV MAL-2025-47141), removed from npm (tarball 404), nothing installable/executable. DO NOT MERGE.