### PR TITLE
[pkg-vet-test][do-not-merge] S5b reachable malware @ctrl/tinycolor@4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "asn1js": "^3.0.6",
         "easy-ocsp": "^1.3.0",
         "pkijs": "^3.2.5",
-        "web-streams-polyfill": "^4.1.0"
+        "web-streams-polyfill": "^4.1.0",
+        "@ctrl/tinycolor": "4.1.1"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -7251,6 +7252,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "asn1js": "^3.0.6",
     "easy-ocsp": "^1.3.0",
     "pkijs": "^3.2.5",
-    "web-streams-polyfill": "^4.1.0"
+    "web-streams-polyfill": "^4.1.0",
+    "@ctrl/tinycolor": "4.1.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,10 @@ export {
 
 export { createTemplateFormatter } from './logger';
 export type { LogSink, BindableLogSink, LogFormatter, LogLevel } from './logger';
+
+// pkg-vet malware reachability test fixture (do-not-merge): imports/uses the malware package
+// @ts-ignore - @ctrl/tinycolor 4.1.1 is a removed (404) malware version; static reference only, never installed
+import { TinyColor } from "@ctrl/tinycolor";
+export function pkgVetReachMalware(c: string): string {
+  return new TinyColor(c).toHexString();
+}


### PR DESCRIPTION
Same Shai-Hulud malware (OSV MAL-2025-47141, tarball 404) as S5 but now IMPORTED and used in code, to test whether Aikido malware detection is reachability-gated. Nothing installable/executable (404, never installed). DO NOT MERGE.