### PR TITLE
[pkg-vet-test][do-not-merge] S6 recent removed malware @redhat-cloud-services/compliance-client@4.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "asn1js": "^3.0.6",
         "easy-ocsp": "^1.3.0",
         "pkijs": "^3.2.5",
-        "web-streams-polyfill": "^4.1.0"
+        "web-streams-polyfill": "^4.1.0",
+        "@redhat-cloud-services/compliance-client": "4.0.3"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -7251,6 +7252,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@redhat-cloud-services/compliance-client": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/compliance-client/-/compliance-client-4.0.3.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "asn1js": "^3.0.6",
     "easy-ocsp": "^1.3.0",
     "pkijs": "^3.2.5",
-    "web-streams-polyfill": "^4.1.0"
+    "web-streams-polyfill": "^4.1.0",
+    "@redhat-cloud-services/compliance-client": "4.0.3"
   }
 }


### PR DESCRIPTION
Throwaway fixture for Aikido Malware Scan, recency test. @redhat-cloud-services/compliance-client@4.0.3 was published+removed today (2026-06-01), flagged MALWARE in Aikido Intel, tarball 404 (removed, burned version, legit Red Hat scope). Nothing installable/executable. DO NOT MERGE.